### PR TITLE
Allow Magic Castle to use an existing resource group

### DIFF
--- a/azure/azure.tf
+++ b/azure/azure.tf
@@ -2,6 +2,9 @@ variable "location" {
 }
 
 variable "azure_resource_group" {
+  description = "Define the name of an existing resource group that will be used when creating the computing resources. If left empty, terraform will create a new resource group."
+  type = string
+  default = ""
 }
 
 variable "managed_disk_type" {

--- a/azure/azure.tf
+++ b/azure/azure.tf
@@ -1,6 +1,9 @@
 variable "location" {
 }
 
+variable "azure_resource_group" {
+}
+
 variable "managed_disk_type" {
   default = "Premium_LRS"
 }

--- a/azure/infrastructure.tf
+++ b/azure/infrastructure.tf
@@ -1,6 +1,5 @@
 # Configure the Microsoft Azure Provider
 provider "azurerm" {
-  version = "~>2.0.0"
   features {}
 }
 
@@ -16,13 +15,13 @@ resource "azurerm_virtual_network" "virtualNetwork" {
   name                = "${var.cluster_name}_vnet"
   address_space       = ["10.0.0.0/16"]
   location            = var.location
-  resource_group_name = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group.name : var.azure_resource_group
+  resource_group_name = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group[0].name : var.azure_resource_group
 }
 
 # Create subnet
 resource "azurerm_subnet" "subnet" {
   name                 = "${var.cluster_name}_subnet"
-  resource_group_name  = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group.name : var.azure_resource_group
+  resource_group_name  = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group[0].name : var.azure_resource_group
   virtual_network_name = azurerm_virtual_network.virtualNetwork.name
   address_prefix       = local.cidr
 }
@@ -32,7 +31,7 @@ resource "azurerm_public_ip" "loginIP" {
   count                        = var.instances["login"]["count"]
   name                         = format("%s-login-ip-%d", var.cluster_name, count.index + 1)
   location                     = var.location
-  resource_group_name          = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group.name : var.azure_resource_group
+  resource_group_name          = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group[0].name : var.azure_resource_group
   allocation_method            = "Static"
 }
 
@@ -40,7 +39,7 @@ resource "azurerm_public_ip" "mgmtIP" {
   count                        = var.instances["mgmt"]["count"]
   name                         = format("%s-mgmt-ip-%d", var.cluster_name, count.index + 1)
   location                     = var.location
-  resource_group_name          = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group.name : var.azure_resource_group
+  resource_group_name          = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group[0].name : var.azure_resource_group
   allocation_method            = "Dynamic"
 }
 
@@ -48,7 +47,7 @@ resource "azurerm_public_ip" "nodeIP" {
   for_each            = local.node
   name                = format("%s-%s-ip", var.cluster_name, each.key)
   location            = var.location
-  resource_group_name = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group.name : var.azure_resource_group
+  resource_group_name = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group[0].name : var.azure_resource_group
   allocation_method   = "Dynamic"
 }
 
@@ -56,7 +55,7 @@ resource "azurerm_public_ip" "nodeIP" {
 resource "azurerm_network_security_group" "security_login" {
   name                = "${var.cluster_name}_login-firewall"
   location            = var.location
-  resource_group_name = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group.name : var.azure_resource_group
+  resource_group_name = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group[0].name : var.azure_resource_group
 
   dynamic "security_rule" {
     for_each = var.firewall_rules
@@ -78,7 +77,7 @@ resource "azurerm_network_security_group" "security_login" {
 resource "azurerm_network_security_group" "security_mgmt" {
   name                = "${var.cluster_name}_mgmt-firewall"
   location            = var.location
-  resource_group_name = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group.name : var.azure_resource_group
+  resource_group_name = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group[0].name : var.azure_resource_group
 
   security_rule {
     name                       = "SSH"
@@ -98,7 +97,7 @@ resource "azurerm_network_interface" "loginNIC" {
   count                     = var.instances["login"]["count"]
   name                      = format("%s-login%d-nic", var.cluster_name, count.index + 1)
   location                  = var.location
-  resource_group_name       = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group.name : var.azure_resource_group
+  resource_group_name       = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group[0].name : var.azure_resource_group
 
   ip_configuration {
     name                          = "${var.cluster_name}_login_nicconfig"
@@ -118,7 +117,7 @@ resource "azurerm_network_interface" "mgmtNIC" {
   count                     = var.instances["mgmt"]["count"]
   name                      = format("%s-mgmt%d-nic", var.cluster_name, count.index + 1)
   location                  = var.location
-  resource_group_name       = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group.name : var.azure_resource_group
+  resource_group_name       = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group[0].name : var.azure_resource_group
 
   ip_configuration {
     name                          = "${var.cluster_name}_mgmt_nicconfig"
@@ -138,7 +137,7 @@ resource "azurerm_network_interface" "nodeNIC" {
   for_each            = local.node
   name                = format("%s-%s-nic", var.cluster_name, each.key)
   location            = var.location
-  resource_group_name = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group.name : var.azure_resource_group
+  resource_group_name = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group[0].name : var.azure_resource_group
 
   ip_configuration {
     name                          = format("%s-%s-ipconfig", var.cluster_name, each.key)
@@ -154,7 +153,7 @@ resource "azurerm_linux_virtual_machine" "login" {
   size                  = var.instances["login"]["type"]
   name                  = format("%s-login%d", var.cluster_name, count.index + 1)
   location              = var.location
-  resource_group_name   = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group.name : var.azure_resource_group
+  resource_group_name   = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group[0].name : var.azure_resource_group
   network_interface_ids = [azurerm_network_interface.loginNIC[count.index].id]
 
   os_disk {
@@ -199,7 +198,7 @@ resource "azurerm_linux_virtual_machine" "mgmt" {
   size               = var.instances["mgmt"]["type"]
   name                  = format("%s-mgmt%d", var.cluster_name, count.index + 1)
   location              = var.location
-  resource_group_name   = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group.name : var.azure_resource_group
+  resource_group_name   = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group[0].name : var.azure_resource_group
   network_interface_ids = [azurerm_network_interface.mgmtNIC[count.index].id]
 
   os_disk {
@@ -241,7 +240,7 @@ resource "azurerm_managed_disk" "home" {
   count                = lower(var.storage["type"]) == "nfs" ? 1 : 0
   name                 = "${var.cluster_name}_home"
   location             = var.location
-  resource_group_name  = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group.name : var.azure_resource_group
+  resource_group_name  = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group[0].name : var.azure_resource_group
   storage_account_type = var.managed_disk_type
   create_option        = "Empty"
   disk_size_gb         = var.storage["home_size"]
@@ -251,7 +250,7 @@ resource "azurerm_managed_disk" "project" {
   count                = lower(var.storage["type"]) == "nfs" ? 1 : 0
   name                 = "${var.cluster_name}_project"
   location             = var.location
-  resource_group_name  = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group.name : var.azure_resource_group
+  resource_group_name  = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group[0].name : var.azure_resource_group
   storage_account_type = var.managed_disk_type
   create_option        = "Empty"
   disk_size_gb         = var.storage["project_size"]
@@ -261,7 +260,7 @@ resource "azurerm_managed_disk" "scratch" {
   count                = lower(var.storage["type"]) == "nfs" ? 1 : 0
   name                 = "${var.cluster_name}_scratch"
   location             = var.location
-  resource_group_name  = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group.name : var.azure_resource_group
+  resource_group_name  = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group[0].name : var.azure_resource_group
   storage_account_type = var.managed_disk_type
   create_option        = "Empty"
   disk_size_gb         = var.storage["scratch_size"]
@@ -315,7 +314,7 @@ resource "azurerm_linux_virtual_machine" "node" {
   name                  = each.value["name"]
   size                  = each.value["type"]
   location              = each.value["location"]
-  resource_group_name   = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group.name : var.azure_resource_group
+  resource_group_name   = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group[0].name : var.azure_resource_group
   network_interface_ids = [azurerm_network_interface.nodeNIC[each.key].id]
 
   source_image_reference {

--- a/azure/infrastructure.tf
+++ b/azure/infrastructure.tf
@@ -1,5 +1,6 @@
 # Configure the Microsoft Azure Provider
 provider "azurerm" {
+  version = "~>2.0.0"
   features {}
 }
 

--- a/azure/infrastructure.tf
+++ b/azure/infrastructure.tf
@@ -4,6 +4,12 @@ provider "azurerm" {
   features {}
 }
 
+# Check if user provided resource group is valid
+data "azurerm_resource_group" "example" {
+  count = var.azure_resource_group == "" ? 0 : 1
+  name = var.azure_resource_group
+}
+
 # Create a resource group
 resource "azurerm_resource_group" "group" {
   count    = var.azure_resource_group == "" ? 1 : 0

--- a/azure/infrastructure.tf
+++ b/azure/infrastructure.tf
@@ -6,6 +6,7 @@ provider "azurerm" {
 
 # Create a resource group
 resource "azurerm_resource_group" "group" {
+  count    = length(var.azure_resource_group) == 0 ? 1 : 0
   name     = "${var.cluster_name}_resource_group"
   location = var.location
 }
@@ -15,13 +16,13 @@ resource "azurerm_virtual_network" "virtualNetwork" {
   name                = "${var.cluster_name}_vnet"
   address_space       = ["10.0.0.0/16"]
   location            = var.location
-  resource_group_name = azurerm_resource_group.group.name
+  resource_group_name = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group.name : var.azure_resource_group
 }
 
 # Create subnet
 resource "azurerm_subnet" "subnet" {
   name                 = "${var.cluster_name}_subnet"
-  resource_group_name  = azurerm_resource_group.group.name
+  resource_group_name  = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group.name : var.azure_resource_group
   virtual_network_name = azurerm_virtual_network.virtualNetwork.name
   address_prefix       = local.cidr
 }
@@ -31,7 +32,7 @@ resource "azurerm_public_ip" "loginIP" {
   count                        = var.instances["login"]["count"]
   name                         = format("%s-login-ip-%d", var.cluster_name, count.index + 1)
   location                     = var.location
-  resource_group_name          = azurerm_resource_group.group.name
+  resource_group_name          = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group.name : var.azure_resource_group
   allocation_method            = "Static"
 }
 
@@ -39,7 +40,7 @@ resource "azurerm_public_ip" "mgmtIP" {
   count                        = var.instances["mgmt"]["count"]
   name                         = format("%s-mgmt-ip-%d", var.cluster_name, count.index + 1)
   location                     = var.location
-  resource_group_name          = azurerm_resource_group.group.name
+  resource_group_name          = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group.name : var.azure_resource_group
   allocation_method            = "Dynamic"
 }
 
@@ -47,7 +48,7 @@ resource "azurerm_public_ip" "nodeIP" {
   for_each            = local.node
   name                = format("%s-%s-ip", var.cluster_name, each.key)
   location            = var.location
-  resource_group_name = azurerm_resource_group.group.name
+  resource_group_name = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group.name : var.azure_resource_group
   allocation_method   = "Dynamic"
 }
 
@@ -55,7 +56,7 @@ resource "azurerm_public_ip" "nodeIP" {
 resource "azurerm_network_security_group" "security_login" {
   name                = "${var.cluster_name}_login-firewall"
   location            = var.location
-  resource_group_name = azurerm_resource_group.group.name
+  resource_group_name = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group.name : var.azure_resource_group
 
   dynamic "security_rule" {
     for_each = var.firewall_rules
@@ -77,7 +78,7 @@ resource "azurerm_network_security_group" "security_login" {
 resource "azurerm_network_security_group" "security_mgmt" {
   name                = "${var.cluster_name}_mgmt-firewall"
   location            = var.location
-  resource_group_name = azurerm_resource_group.group.name
+  resource_group_name = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group.name : var.azure_resource_group
 
   security_rule {
     name                       = "SSH"
@@ -97,7 +98,7 @@ resource "azurerm_network_interface" "loginNIC" {
   count                     = var.instances["login"]["count"]
   name                      = format("%s-login%d-nic", var.cluster_name, count.index + 1)
   location                  = var.location
-  resource_group_name       = azurerm_resource_group.group.name
+  resource_group_name       = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group.name : var.azure_resource_group
 
   ip_configuration {
     name                          = "${var.cluster_name}_login_nicconfig"
@@ -117,7 +118,7 @@ resource "azurerm_network_interface" "mgmtNIC" {
   count                     = var.instances["mgmt"]["count"]
   name                      = format("%s-mgmt%d-nic", var.cluster_name, count.index + 1)
   location                  = var.location
-  resource_group_name       = azurerm_resource_group.group.name
+  resource_group_name       = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group.name : var.azure_resource_group
 
   ip_configuration {
     name                          = "${var.cluster_name}_mgmt_nicconfig"
@@ -137,7 +138,7 @@ resource "azurerm_network_interface" "nodeNIC" {
   for_each            = local.node
   name                = format("%s-%s-nic", var.cluster_name, each.key)
   location            = var.location
-  resource_group_name = azurerm_resource_group.group.name
+  resource_group_name = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group.name : var.azure_resource_group
 
   ip_configuration {
     name                          = format("%s-%s-ipconfig", var.cluster_name, each.key)
@@ -153,7 +154,7 @@ resource "azurerm_linux_virtual_machine" "login" {
   size                  = var.instances["login"]["type"]
   name                  = format("%s-login%d", var.cluster_name, count.index + 1)
   location              = var.location
-  resource_group_name   = azurerm_resource_group.group.name
+  resource_group_name   = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group.name : var.azure_resource_group
   network_interface_ids = [azurerm_network_interface.loginNIC[count.index].id]
 
   os_disk {
@@ -198,7 +199,7 @@ resource "azurerm_linux_virtual_machine" "mgmt" {
   size               = var.instances["mgmt"]["type"]
   name                  = format("%s-mgmt%d", var.cluster_name, count.index + 1)
   location              = var.location
-  resource_group_name   = azurerm_resource_group.group.name
+  resource_group_name   = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group.name : var.azure_resource_group
   network_interface_ids = [azurerm_network_interface.mgmtNIC[count.index].id]
 
   os_disk {
@@ -240,7 +241,7 @@ resource "azurerm_managed_disk" "home" {
   count                = lower(var.storage["type"]) == "nfs" ? 1 : 0
   name                 = "${var.cluster_name}_home"
   location             = var.location
-  resource_group_name  = azurerm_resource_group.group.name
+  resource_group_name  = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group.name : var.azure_resource_group
   storage_account_type = var.managed_disk_type
   create_option        = "Empty"
   disk_size_gb         = var.storage["home_size"]
@@ -250,7 +251,7 @@ resource "azurerm_managed_disk" "project" {
   count                = lower(var.storage["type"]) == "nfs" ? 1 : 0
   name                 = "${var.cluster_name}_project"
   location             = var.location
-  resource_group_name  = azurerm_resource_group.group.name
+  resource_group_name  = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group.name : var.azure_resource_group
   storage_account_type = var.managed_disk_type
   create_option        = "Empty"
   disk_size_gb         = var.storage["project_size"]
@@ -260,7 +261,7 @@ resource "azurerm_managed_disk" "scratch" {
   count                = lower(var.storage["type"]) == "nfs" ? 1 : 0
   name                 = "${var.cluster_name}_scratch"
   location             = var.location
-  resource_group_name  = azurerm_resource_group.group.name
+  resource_group_name  = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group.name : var.azure_resource_group
   storage_account_type = var.managed_disk_type
   create_option        = "Empty"
   disk_size_gb         = var.storage["scratch_size"]
@@ -314,7 +315,7 @@ resource "azurerm_linux_virtual_machine" "node" {
   name                  = each.value["name"]
   size                  = each.value["type"]
   location              = each.value["location"]
-  resource_group_name   = azurerm_resource_group.group.name
+  resource_group_name   = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group.name : var.azure_resource_group
   network_interface_ids = [azurerm_network_interface.nodeNIC[each.key].id]
 
   source_image_reference {

--- a/azure/infrastructure.tf
+++ b/azure/infrastructure.tf
@@ -6,7 +6,7 @@ provider "azurerm" {
 
 # Create a resource group
 resource "azurerm_resource_group" "group" {
-  count    = length(var.azure_resource_group) == 0 ? 1 : 0
+  count    = var.azure_resource_group == "" ? 1 : 0
   name     = "${var.cluster_name}_resource_group"
   location = var.location
 }
@@ -16,13 +16,13 @@ resource "azurerm_virtual_network" "virtualNetwork" {
   name                = "${var.cluster_name}_vnet"
   address_space       = ["10.0.0.0/16"]
   location            = var.location
-  resource_group_name = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group[0].name : var.azure_resource_group
+  resource_group_name = local.resource_group_name
 }
 
 # Create subnet
 resource "azurerm_subnet" "subnet" {
   name                 = "${var.cluster_name}_subnet"
-  resource_group_name  = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group[0].name : var.azure_resource_group
+  resource_group_name  = local.resource_group_name
   virtual_network_name = azurerm_virtual_network.virtualNetwork.name
   address_prefix       = local.cidr
 }
@@ -32,7 +32,7 @@ resource "azurerm_public_ip" "loginIP" {
   count                        = var.instances["login"]["count"]
   name                         = format("%s-login-ip-%d", var.cluster_name, count.index + 1)
   location                     = var.location
-  resource_group_name          = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group[0].name : var.azure_resource_group
+  resource_group_name          = local.resource_group_name
   allocation_method            = "Static"
 }
 
@@ -40,7 +40,7 @@ resource "azurerm_public_ip" "mgmtIP" {
   count                        = var.instances["mgmt"]["count"]
   name                         = format("%s-mgmt-ip-%d", var.cluster_name, count.index + 1)
   location                     = var.location
-  resource_group_name          = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group[0].name : var.azure_resource_group
+  resource_group_name          = local.resource_group_name
   allocation_method            = "Dynamic"
 }
 
@@ -48,7 +48,7 @@ resource "azurerm_public_ip" "nodeIP" {
   for_each            = local.node
   name                = format("%s-%s-ip", var.cluster_name, each.key)
   location            = var.location
-  resource_group_name = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group[0].name : var.azure_resource_group
+  resource_group_name = local.resource_group_name
   allocation_method   = "Dynamic"
 }
 
@@ -56,7 +56,7 @@ resource "azurerm_public_ip" "nodeIP" {
 resource "azurerm_network_security_group" "security_login" {
   name                = "${var.cluster_name}_login-firewall"
   location            = var.location
-  resource_group_name = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group[0].name : var.azure_resource_group
+  resource_group_name = local.resource_group_name
 
   dynamic "security_rule" {
     for_each = var.firewall_rules
@@ -78,7 +78,7 @@ resource "azurerm_network_security_group" "security_login" {
 resource "azurerm_network_security_group" "security_mgmt" {
   name                = "${var.cluster_name}_mgmt-firewall"
   location            = var.location
-  resource_group_name = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group[0].name : var.azure_resource_group
+  resource_group_name = local.resource_group_name
 
   security_rule {
     name                       = "SSH"
@@ -98,7 +98,7 @@ resource "azurerm_network_interface" "loginNIC" {
   count                     = var.instances["login"]["count"]
   name                      = format("%s-login%d-nic", var.cluster_name, count.index + 1)
   location                  = var.location
-  resource_group_name       = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group[0].name : var.azure_resource_group
+  resource_group_name       = local.resource_group_name
 
   ip_configuration {
     name                          = "${var.cluster_name}_login_nicconfig"
@@ -118,7 +118,7 @@ resource "azurerm_network_interface" "mgmtNIC" {
   count                     = var.instances["mgmt"]["count"]
   name                      = format("%s-mgmt%d-nic", var.cluster_name, count.index + 1)
   location                  = var.location
-  resource_group_name       = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group[0].name : var.azure_resource_group
+  resource_group_name       = local.resource_group_name
 
   ip_configuration {
     name                          = "${var.cluster_name}_mgmt_nicconfig"
@@ -138,7 +138,7 @@ resource "azurerm_network_interface" "nodeNIC" {
   for_each            = local.node
   name                = format("%s-%s-nic", var.cluster_name, each.key)
   location            = var.location
-  resource_group_name = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group[0].name : var.azure_resource_group
+  resource_group_name = local.resource_group_name
 
   ip_configuration {
     name                          = format("%s-%s-ipconfig", var.cluster_name, each.key)
@@ -154,7 +154,7 @@ resource "azurerm_linux_virtual_machine" "login" {
   size                  = var.instances["login"]["type"]
   name                  = format("%s-login%d", var.cluster_name, count.index + 1)
   location              = var.location
-  resource_group_name   = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group[0].name : var.azure_resource_group
+  resource_group_name   = local.resource_group_name
   network_interface_ids = [azurerm_network_interface.loginNIC[count.index].id]
 
   os_disk {
@@ -199,7 +199,7 @@ resource "azurerm_linux_virtual_machine" "mgmt" {
   size               = var.instances["mgmt"]["type"]
   name                  = format("%s-mgmt%d", var.cluster_name, count.index + 1)
   location              = var.location
-  resource_group_name   = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group[0].name : var.azure_resource_group
+  resource_group_name   = local.resource_group_name
   network_interface_ids = [azurerm_network_interface.mgmtNIC[count.index].id]
 
   os_disk {
@@ -241,7 +241,7 @@ resource "azurerm_managed_disk" "home" {
   count                = lower(var.storage["type"]) == "nfs" ? 1 : 0
   name                 = "${var.cluster_name}_home"
   location             = var.location
-  resource_group_name  = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group[0].name : var.azure_resource_group
+  resource_group_name  = local.resource_group_name
   storage_account_type = var.managed_disk_type
   create_option        = "Empty"
   disk_size_gb         = var.storage["home_size"]
@@ -251,7 +251,7 @@ resource "azurerm_managed_disk" "project" {
   count                = lower(var.storage["type"]) == "nfs" ? 1 : 0
   name                 = "${var.cluster_name}_project"
   location             = var.location
-  resource_group_name  = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group[0].name : var.azure_resource_group
+  resource_group_name  = local.resource_group_name
   storage_account_type = var.managed_disk_type
   create_option        = "Empty"
   disk_size_gb         = var.storage["project_size"]
@@ -261,7 +261,7 @@ resource "azurerm_managed_disk" "scratch" {
   count                = lower(var.storage["type"]) == "nfs" ? 1 : 0
   name                 = "${var.cluster_name}_scratch"
   location             = var.location
-  resource_group_name  = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group[0].name : var.azure_resource_group
+  resource_group_name  = local.resource_group_name
   storage_account_type = var.managed_disk_type
   create_option        = "Empty"
   disk_size_gb         = var.storage["scratch_size"]
@@ -315,7 +315,7 @@ resource "azurerm_linux_virtual_machine" "node" {
   name                  = each.value["name"]
   size                  = each.value["type"]
   location              = each.value["location"]
-  resource_group_name   = length(var.azure_resource_group) == 0 ? azurerm_resource_group.group[0].name : var.azure_resource_group
+  resource_group_name   = local.resource_group_name
   network_interface_ids = [azurerm_network_interface.nodeNIC[each.key].id]
 
   source_image_reference {
@@ -354,6 +354,7 @@ resource "azurerm_linux_virtual_machine" "node" {
 }
 
 locals {
+  resource_group_name = var.azure_resource_group == "" ? azurerm_resource_group.group[0].name : var.azure_resource_group
   mgmt1_ip        = azurerm_network_interface.mgmtNIC[0].private_ip_address
   puppetmaster_ip = azurerm_network_interface.mgmtNIC[0].private_ip_address
   public_ip       = azurerm_public_ip.loginIP[*].ip_address

--- a/docs/README.md
+++ b/docs/README.md
@@ -496,6 +496,19 @@ Can be used to force a v4 subnet when both v4 and v6 exist.
 
 #### 5.4.2 managed_disk_type (optional)
 
+#### 5.4.3 azure_resource_group (optional)
+
+**default value**: None
+
+Defines the name of an already created resource group to use. Terraform
+will no longer attempt to manage a resource group for Magic Castle if
+this variable is defined and will instead create all resources within
+the provided resource group. Define this if you wish to use an already
+created resource group or you do not have subscription level access to
+create and destroy resource groups.
+
+**Post Build Modification Effect**: rebuild of all instances at next `terraform apply`.
+
 
 ## 6. DNS Configuration and SSL Certificates
 

--- a/examples/azure/main.tf
+++ b/examples/azure/main.tf
@@ -5,6 +5,9 @@ terraform {
 module "azure" {
   source = "git::https://github.com/ComputeCanada/magic_castle.git//azure"
 
+  # If using a pre-created resource group specify it in azure_resource_group
+  # Otherwise leave the variable empty to allow terraform to manage a new resource group
+  azure_resource_group = ""
   cluster_name = "phoenix"
   domain       = "calculquebec.cloud"
   image        = {

--- a/examples/azure/main.tf
+++ b/examples/azure/main.tf
@@ -5,9 +5,6 @@ terraform {
 module "azure" {
   source = "git::https://github.com/ComputeCanada/magic_castle.git//azure"
 
-  # If using a pre-created resource group specify it in azure_resource_group
-  # Otherwise leave the variable empty to allow terraform to manage a new resource group
-  azure_resource_group = ""
   cluster_name = "phoenix"
   domain       = "calculquebec.cloud"
   image        = {


### PR DESCRIPTION
If user does not have access to create and destroy resource groups at a subscription level, allow user to provide an existing resource group name and only manage resources within that resource group.